### PR TITLE
Potential fix for code scanning alert no. 77: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -17,6 +17,33 @@ export function profileImageUrlUpload () {
   return async (req: Request, res: Response, next: NextFunction) => {
     if (req.body.imageUrl !== undefined) {
       const url = req.body.imageUrl
+      // Prevent SSRF: only allow HTTPS URLs for images from a set of allowed domains
+      let parsedUrl
+      try {
+        parsedUrl = new URL(url)
+      } catch (err) {
+        next(new Error('Invalid URL for profile image.'))
+        return
+      }
+      // Allowlist of hostnames images can be sourced from
+      const allowedHosts = [
+        'images.example.com', // Replace with allowed hosted domains
+        'cdn.example.com'
+      ]
+      // Block IP literal addresses, localhost, and require https protocol
+      // You may need to adjust allowedHosts as per your context
+      const isIpAddress = /^(?:\d{1,3}\.){3}\d{1,3}$/.test(parsedUrl.hostname) || /^\[.*\]$/.test(parsedUrl.hostname)
+      if (
+        parsedUrl.protocol !== 'https:' ||
+        isIpAddress ||
+        parsedUrl.hostname === 'localhost' ||
+        parsedUrl.hostname === '127.0.0.1' ||
+        parsedUrl.hostname === '::1' ||
+        !allowedHosts.includes(parsedUrl.hostname)
+      ) {
+        next(new Error('Blocked potentially unsafe profile image URL.'))
+        return
+      }
       if (url.match(/(.)*solve\/challenges\/server-side(.)*/) !== null) req.app.locals.abused_ssrf_bug = true
       const loggedInUser = security.authenticatedUsers.get(req.cookies.token)
       if (loggedInUser) {


### PR DESCRIPTION
Potential fix for [https://github.com/tiagosrib/juice-shop-ada-1497/security/code-scanning/77](https://github.com/tiagosrib/juice-shop-ada-1497/security/code-scanning/77)

The best way to fix this problem is to restrict which URLs the server is allowed to fetch by validating the `imageUrl` input. Specifically, we should:
- Only allow requests to a strict allowlist of domain(s)/protocol(s), or, if that's not feasible, at the very least only allow well-formed HTTP(S) URLs, and block IP literals (including localhost, private/rfc1918 addresses), local network addresses, and possibly block non-HTTP protocols.
- Ideally, enforce the allowlist at both the hostname and protocol level, for example only allow `https://` URLs from a trusted CDN or image service.
- Additionally, consider enforcing reasonable length limits and denying URLs with suspicious characteristics (e.g., path traversal, userinfo in URL, etc).

To minimize functionality changes, the best fix in this context is to:
- Parse the URL using the built-in Node.js `URL` API.
- Reject (`next(new Error(...))`) or return early for requests where the hostname is not in an allowlist (or where hostname is a localhost, local network, or IP address).
- If more flexible, only allow `https` URLs and public hostnames (no IP literal).
- Place this validation just after line 19, before any use of the URL.

Required: Add a hostname allowlist and block all other values, or enforce only public, well-formed, non-IP URLs over HTTPS.
No new dependencies are needed: use Node.js's `URL` and basic logic.
All code changes are confined to the visible function in `routes/profileImageUrlUpload.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
